### PR TITLE
Zahra bakhtiari/bugfix

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,2 @@
 
-# biokg_bug_fix: the run.py file has a bug when it is running on linux which essentially stops the model from reporting the train/valid/test results gradual each step which is confusing for users
+biokg_bug_fix: the run.py file has a bug when it is running on linux which essentially stops the model from reporting the train/valid/test results gradual each step which is confusing for users

--- a/run.py
+++ b/run.py
@@ -137,12 +137,11 @@ def set_logger(args):
         filemode='w'
     )
 
-    if args.print_on_screen:
-        console = logging.StreamHandler()
-        console.setLevel(logging.INFO)
-        formatter = logging.Formatter('%(asctime)s %(levelname)-8s %(message)s')
-        console.setFormatter(formatter)
-        logging.getLogger('').addHandler(console)
+    console = logging.StreamHandler()
+    console.setLevel(logging.INFO)
+    formatter = logging.Formatter('%(asctime)s %(levelname)-8s %(message)s')
+    console.setFormatter(formatter)
+    logging.getLogger('').addHandler(console)
 
 def log_metrics(mode, step, metrics, writer):
     '''


### PR DESCRIPTION
The biokg training is facing screen freeze because of a bug in run.py which result in not reporting gradual results at each training step. it also prevent the valid and test result from showing up on ubuntu console which can waste tens of hours for a newbie to this repo